### PR TITLE
Fix incorrect graphql import path

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -7,7 +7,7 @@ import {
   subscribe,
   validate,
   GraphQLError,
-} from 'graphql/index.mjs'
+} from 'graphql'
 
 const no_schema_error = () => {
   throw new Error("Option 'schema' is required")


### PR DESCRIPTION
**Description**:

This PR addresses an issue with the import statement of 'graphql'. The previous import statement was using an incorrect path, which could lead to potential conflicts or errors.

**Changes**:

- Update the import statement for 'graphql' by removing the unnecessary '/index.mjs' from the path.

By making this change, we ensure that the 'graphql' package is imported correctly and consistently throughout the project, avoiding any potential issues caused by the incorrect import path.



